### PR TITLE
アセンブラの出力の先頭2行に機械語列のバイト数、_min_caml_startラベルの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ mincaml/powerpcの規約に合わせてtest用の.sファイルとsimulatorを�
 
 bcondで相対アドレスが負のとき違うアドレスに飛んでしまうのを修正
 ba, balを追加
+
+assembler の出力の1行目に実行する機械語列のバイト数
+									2行目に_min_caml_startラベルの示すアドレスを追加　ラベルがない場合0になる
+simulatorでは_min_caml_startラベルのアドレスから命令を実行する
+

--- a/assembler/asm.cpp
+++ b/assembler/asm.cpp
@@ -66,7 +66,8 @@ int main(int argc, char** argv) {
 	}
 
 	uint32_t op;
-	int linenum = 0;
+	uint32_t codeByte = 0;
+	uint32_t mincamlStart = 0;
 	cout << "reading inputfile..." << endl;
 	string line;
 	//labelのset もっとよい方法がある気がする
@@ -88,18 +89,28 @@ int main(int argc, char** argv) {
 		if (vitem[0].find_first_of("#", 0) == 0) {
 			continue;
 		}
+		if (vitem[0].find_first_of(".", 0) == 0) {
+			continue;
+		}
 		if (vitem[0].find_last_of(':') == vitem[0].length()-1) {
 			cout << "label: " << line << endl;
 			vector<string> vtmp = StringSplit(vitem[0], ':');
 			labelMap[vtmp[0]] = PC;
+			if (vtmp[0] == "_min_caml_start") {
+				mincamlStart = PC;
+			}
 			cout << "PC: "<<  hex << PC << dec << endl;
 			continue;
 		}
 		PC += 4;
 	}
+	codeByte = PC;
 	cout << "finish labeling!" << endl;
 	filein.close();
 	//labelの処理終わり
+	cout << "codeByte: " << hex << codeByte << dec << endl;
+	fileout.write((char*)&codeByte, sizeof(uint32_t));
+	fileout.write((char*)&mincamlStart, sizeof(uint32_t));
 
 	ifstream filein2(argv[1]);
 	PC = 0;
@@ -110,7 +121,6 @@ int main(int argc, char** argv) {
 			continue;
 		}
 		cout << "deal with " << line << endl;
-		linenum++;
 		op = encode(line);
 		if (op == 0xFFFFFFFF) {
 			return 1;

--- a/assembler/opAsm.cpp
+++ b/assembler/opAsm.cpp
@@ -71,7 +71,7 @@ uint32_t get_simm16(const string str) {
 		} catch (const invalid_argument& e) {
 			try{
 				simm16 = labelMap.at(vtmp[1]);
-				cout << "ha(label)" << hex << simm16 << dec << endl;
+				cout << "label address: " << hex << simm16 << dec << endl;
 				return ((simm16 >> 16) & 0x0000FFFF);
 			} catch (const out_of_range&) {
 				cerr << "error in simm16...invalid_argument or undefined label" << endl;
@@ -88,7 +88,7 @@ uint32_t get_simm16(const string str) {
 		} catch (const invalid_argument& e) {
 			try{
 				simm16 = labelMap.at(vtmp[1]);
-				cout << "lo(label)" << hex << simm16 << dec << endl;
+				cout << "label address: " << hex << simm16 << dec << endl;
 				return (simm16 & 0x0000FFFF);
 			} catch (const out_of_range&) {
 				cerr << "error in simm16...invalid_argument or undefined label" << endl;

--- a/assembler/test/add.s
+++ b/assembler/test/add.s
@@ -2,8 +2,12 @@ calc:
 	li r1, 4
 	addi r2, r1, 16
 	add r5, r2, r1
+_min_caml_start:
+	li r5, 5
+	addi r6, r5, 30
+	add r7, r6, r5
 end:
-	li r6, ha(0x4321478)
-	li r7, lo(end)
+	li r8, ha(0x4321478)
+	li r9, lo(end)
 	mr r1, r5
 

--- a/simulator/sim.cpp
+++ b/simulator/sim.cpp
@@ -62,6 +62,7 @@ uint32_t DATA_MEM[DATA_ADDR] = {};//データを保存するメモリ
 
 uint32_t PC;
 uint32_t OP;
+uint32_t mincamlStart;
 
 int lastPC;
 //bitを取り出す
@@ -209,7 +210,7 @@ void debug() {
 }
 
 int normal() {
-	PC = 0;
+	PC = mincamlStart >> 2;
 	GPR[3] = 0x8000;//stack
 	while(PC < lastPC) {
 		int result = do_op();
@@ -225,7 +226,7 @@ int normal() {
 
 int step() {
 	cout << "execute by step..." << endl;
-	PC = 0;
+	PC = mincamlStart >> 2;
 	GPR[3] = 0x8000;//stack
 	//uint32_t breakpoint = 0;
 	vector<uint32_t> breakpoint;
@@ -394,6 +395,11 @@ int main(int argc, char**argv) {
 	size_t cnt;
 	size_t pos = 0;
 	cout << "reading instruction..." << endl;
+	uint32_t codeByte;
+	fread(&codeByte, 4, 1, binary);
+	cout << "byte of code: " << hex << codeByte << dec << endl;
+	fread(&mincamlStart, 4, 1, binary);
+	cout << "_min_caml_start label address: " << hex << mincamlStart << dec << endl;
 	while ((cnt = fread(&INST_MEM[pos], 4, 2048, binary))) {
 		pos += cnt;
 	} 


### PR DESCRIPTION
simulator上では_min_caml_startラベルから実行